### PR TITLE
Fix missing events due to race condition

### DIFF
--- a/Tracks Vigilante/popup.js
+++ b/Tracks Vigilante/popup.js
@@ -25,7 +25,6 @@
     const reloadButton = document.getElementById("reload");
     const table = document.getElementById("table");
     const filter = document.getElementById("filter");
-    const stats = document.getElementById("data");
     const extended = document.getElementById("extended");
     const select = document.getElementById("select-container");
 
@@ -57,8 +56,7 @@
      * It also sets the badge in the Chrome Extension Icon to 0.
      */
     function clearContents() {
-        chrome.action.setBadgeText({ text: "" });
-        chrome.storage.local.set({ url_array: [] }, () => stats.innerHTML = null);
+        chrome.runtime.sendMessage({ msg: "Clear" });
         reload();
     }
 


### PR DESCRIPTION
## Quick summary

**Tracks Vigilante** relies on `webRequest.onCompleted` event to update the storage. However, if the two events fired at the same time, one of them might be gone. As they got the same url_array, the data would be overwritten by the latter one. Thus, I propose to store the `url_array` in memory and sync to storage when every update.

## Steps to reproduce

1. Go to `/start`
2. Check the following event always fires or not
  ![image](https://user-images.githubusercontent.com/13596067/140896306-d9495e75-a36b-41d3-9148-81196a78c6b6.png)

## What you expected to happen

The event `calypso_signup_start` should always fire with `flow: onboarding`

## What actually happened

Sometimes, we cannot see the event `calypso_signup_start` with `flow: onboarding`

## Reference

https://github.com/Automattic/wp-calypso/issues/57779