### PR TITLE
Make the extension firefox compatible

### DIFF
--- a/Tracks Vigilante/manifest.json
+++ b/Tracks Vigilante/manifest.json
@@ -1,32 +1,30 @@
 {
     "name": "Tracks Vigilante",
-    "manifest_version": 3,
+    "manifest_version": 2,
     "version": "1.1",
     "description": "Tracks network calls to Tracks",
     "permissions": [
       "activeTab",
-      "scripting",
-      "background", 
       "webRequest",
       "storage"
     ],
-    "icons": { 
+    "icons": {
       "16": "/icons/tv16.png",
       "48": "/icons/tv48.png",
-     "128": "/icons/tv128.png" 
+     "128": "/icons/tv128.png"
     },
     "background": {
-      "service_worker": "service-worker.js"
+      "scripts": ["service-worker.js"]
     },
-    "action": {
-      "default_icon": { 
+    "browser_action": {
+      "default_icon": {
         "16": "/icons/tv16.png",
         "48": "/icons/tv48.png",
-       "128": "/icons/tv128.png" 
+       "128": "/icons/tv128.png"
       },
       "default_popup": "popup.html"
     },
-    "host_permissions": [
+    "optional_permissions": [
       "http://pixel.wp.com/",
       "https://pixel.wp.com/",
       "*://*/*"

--- a/Tracks Vigilante/service-worker.js
+++ b/Tracks Vigilante/service-worker.js
@@ -22,7 +22,7 @@
   };
 
   // See: https://developer.chrome.com/docs/extensions/reference/storage/#asynchronous-preload-from-storage
-  chrome.action.onClicked.addListener(async () => {
+  browser.browserAction.onClicked.addListener(async () => {
     try {
       await initStorage();
     } catch ( error ) {
@@ -122,7 +122,7 @@
    * @param { TrackEvent[] } trackEvents our data array
    */
   function updateBadge( trackEvents ) {
-    chrome.action.setBadgeText({ text: trackEvents.length > 0 ? trackEvents.length.toString() : "" });
+    browser.browserAction.setBadgeText({ text: trackEvents.length > 0 ? trackEvents.length.toString() : "" });
   }
 
   /**
@@ -176,11 +176,10 @@
     if (lifeline) return;
     for (const tab of await chrome.tabs.query({ url: '*://*/*' })) {
       try {
-        await chrome.scripting.executeScript({
-          target: { tabId: tab.id },
-          function: () => chrome.runtime.connect({ name: 'keepAlive' }),
-          // `function` will become `func` in Chrome 93+
-        });
+       browser.tabs.executeScript(
+        tab.id,
+        { code: `chrome.runtime.connect({ name: 'keepAlive' })` }
+       );
         chrome.tabs.onUpdated.removeListener(retryOnTabUpdate);
         return;
       } catch (e) { }


### PR DESCRIPTION
As firefox does not yet fully support manifest v3 this requires a
downgrade to manifest v2 and some knock-on effects.

This has broken chrome compatibility so some further work is required to
have a single repo for chrome + firefox.

It can be tested in firefox by:
 1. Cloning the repo and checking out this branch
 2. In firefox visit about:debugging#/runtime/this-firefox
 3. Choose Load Temporary Add-on and then select the manifest.json