### PR TITLE
Allow filtering by multiple events

### DIFF
--- a/Tracks Vigilante/manifest.json
+++ b/Tracks Vigilante/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Tracks Vigilante",
     "manifest_version": 3,
-    "version": "1.3",
+    "version": "1.4",
     "description": "Tracks network calls to Tracks",
     "permissions": [
       "activeTab",

--- a/Tracks Vigilante/popup.js
+++ b/Tracks Vigilante/popup.js
@@ -46,7 +46,7 @@
      * Elements init values
      */
   let filterProperty = '';
-  let selectorValue = 'ALL';
+  const selectorValues = [ 'ALL' ];
   if ( standaloneButton == null ) {
     extended.checked = true;
   }
@@ -65,7 +65,9 @@
      * @param {Event} event
      */
   function filterSelector ( event ) {
-    selectorValue = event?.target?.value?.trim();
+    selectorValues.length = 0;
+    selectorValues.push( ... [...event?.target?.options].filter(option => option.selected).map(option => option.value) );
+    console.log( selectorValues );
     reload();
   }
 
@@ -75,7 +77,7 @@
      */
   function createKeySelector ( data ) {
     return `
-        <select name="keys" id="keys">
+        <select name="keys" id="keys" multiple >
             <option value="ALL">ALL</option>
             ${ getFilters( data ) }
         </select>`;
@@ -121,7 +123,7 @@
       let customKey = element.key;
       const parameters = [];
       const extendedParameters = [];
-      if ( element.key === selectorValue || selectorValue === '' || selectorValue === 'ALL' ) {
+      if ( selectorValues.some( item => [ element.key, 'ALL', '' ].includes( item ) ) ) {
         for ( const [ key, value ] of Object.entries( element.values ) ) {
           if ( typeSelected === 'ALL' || typeSelected === element.type ) {
             if ( filterProperty === '' || filterProperty == null || key.toLowerCase().includes( filterProperty.toLowerCase() ) ||
@@ -258,7 +260,7 @@
       if ( !element ) {
         return;
       }
-      html += `<option value="${ element }" ${ element === selectorValue ? 'selected' : '' }>${ element }</option>`;
+      html += `<option value="${ element }" ${  selectorValues.includes( element ) ? 'selected' : '' }>${ element }</option>`;
     } );
     return html;
   }


### PR DESCRIPTION
This small refactor provides the ability to filter multiple events in the select filter, rather than just the one.

This is done by using existing properties of the HTML select element to enable multiple options.

<img width="509" alt="Screenshot 2022-02-01 at 11 58 13 PM" src="https://user-images.githubusercontent.com/277661/152065637-3f3bbad0-1722-4a76-b1e5-72dcd3e3be96.png">

